### PR TITLE
Update tsconfig.json

### DIFF
--- a/packages/origin-api/tsconfig.json
+++ b/packages/origin-api/tsconfig.json
@@ -5,6 +5,7 @@
     "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "esModuleInterop": true,
     "target": "es2017",
     "sourceMap": true,
     "outDir": "./dist",


### PR DESCRIPTION
@types/bn.js/index"' can only be default-imported using the 'esModuleInterop' flag